### PR TITLE
feat: name validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 decomp
 game
 .DS_Store
+.vs

--- a/src/GSFGetClientVersionInfoHandler.cs
+++ b/src/GSFGetClientVersionInfoHandler.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+// we'll probably end up with a misc service or something,
+// but this works for now
+class GSFGetClientVersionInfoHandler : IServiceHandler
+{
+    public GSFService.GSFResponse Handle(GSFService.GSFRequest request)
+    {
+        Console.WriteLine($"Client connected");
+        return new GSFGetClientVersionInfoSvc.GSFResponse
+        {
+            clientVersionInfo = "0.0.0"
+        };
+    }
+}

--- a/src/GSFValidateNameHandler.cs
+++ b/src/GSFValidateNameHandler.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+public class GSFValidateNameHandler : IServiceHandler
+{
+    // given a username, returns an empty or null string if the username is valid (i.e. not filtered)
+    // presumably the string should be filled with the filtered words, but this is never used clientside
+    public GSFService.GSFResponse Handle(GSFService.GSFRequest request)
+    {
+        return new GSFValidateNameSvc.GSFResponse
+        {
+            filterName = null
+        };
+    }
+}

--- a/src/IServiceHandler.cs
+++ b/src/IServiceHandler.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+interface IServiceHandler
+{
+    GSFService.GSFResponse Handle(GSFService.GSFRequest request);
+}

--- a/src/ServerClient.cs
+++ b/src/ServerClient.cs
@@ -107,16 +107,23 @@ class ServerClient
 
             if (message is GSFRequestMessage request)
             {
-                if (request.Body is GSFGetClientVersionInfoSvc.GSFRequest body)
+                GSFService.GSFResponse response = null;
+                switch (request.Body)
                 {
-                    Console.WriteLine($"Client connected: {body.clientName}");
+                    case GSFGetClientVersionInfoSvc.GSFRequest body:
+                        response = new GSFGetClientVersionInfoHandler().Handle(body);
+                        break;
+                    case GSFValidateNameSvc.GSFRequest body:
+                        response = new GSFValidateNameHandler().Handle(body);
+                        break;
+                }
+                if (!(response is null))
+                {
                     messageQueue.Enqueue(
                         new ServerResponseMessage(
                             ServiceClass.UserServer,
-                            GSFUserMessageTypes.GET_CLIENT_VERSION_INFO,
-                            new GSFGetClientVersionInfoSvc.GSFResponse {
-                                clientVersionInfo = "0.0.0"
-                            }
+                            request.Header.msgType,
+                            response
                         )
                     );
                 }


### PR DESCRIPTION
adds handler interface as discussed, and support for name validation as part of creating a new account
not totally happy with taking the IServiceHandler.Handle request parameter as a generic GSFService.GSFRequest and recasting it after when the router already knows the correct type. i tried making the interface generic but returning a T.GSFResponse isn't supported - there's probably a better way to do this?